### PR TITLE
Выбор размера памяти переносится на этап сборки

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ src/external/
 
 *.log
 *.log.bak
+__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+# Build settings
+# EEPROM
+# Values: 1-7 
+# See: src/driver/eeprom.h 1:BL24C64 / 2:BL24C128 / 3:BL24C256 / 4:BL24C512 / 5:BL24C1024 / 6:M24M02 / 7:M24M02x2
+EEPROM ?= 5
+
 SRC_DIR := src
 OBJ_DIR := obj
 BIN_DIR := bin
@@ -37,6 +43,7 @@ CFLAGS = -Os -Wall -Wno-error -mcpu=cortex-m0 -fno-builtin -fshort-enums -fno-de
 CFLAGS += -DPRINTF_INCLUDE_CONFIG_H
 CFLAGS += -DGIT_HASH=\"$(GIT_HASH)\"
 CFLAGS += -DTIME_STAMP=\"$(TS)\"
+CFLAGS += -D__EEPROM=$(EEPROM)
 LDFLAGS = -mcpu=cortex-m0 -nostartfiles -Wl,-T,firmware.ld
 
 INC =
@@ -70,7 +77,7 @@ $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c | $(BSP_HEADERS) $(OBJ_DIR)
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.S | $(OBJ_DIR)
 	$(AS) $(ASFLAGS) $< -o $@
 
-$(BIN_DIR) $(OBJ_DIR) $(BIN_DIR):
+$(BIN_DIR) $(OBJ_DIR):
 	mkdir -p $@
 
 .FORCE:

--- a/chirp/chirp_uvk5_fagci_reborn.py
+++ b/chirp/chirp_uvk5_fagci_reborn.py
@@ -793,12 +793,12 @@ CH_SIZE = 23
 EEPROM_SIZES = [
     8192,  # 000
     8192,  # 001
-    8192,  # 010
-    16384,  # 011
-    32768,  # 100
-    65536,  # 101
-    131072,  # 110
-    262144,  # 111
+    16384,  # 010
+    32768,  # 011
+    65536,  # 100
+    131072,  # 101
+    262144,  # 110
+    524288,  # 111
 ]
 
 RADIO_LIST = [
@@ -893,14 +893,14 @@ SCAN_TIMEOUT = [
 ]
 
 EEPROM_TYPE = [
-    "EEPROM_A",
-    "EEPROM_B",
+    "EEPROM_BL24C64",
     "EEPROM_BL24C64",
     "EEPROM_BL24C128",
     "EEPROM_BL24C256",
     "EEPROM_BL24C512",
     "EEPROM_BL24C1024",
-    "EEPROM_M24M02"
+    "EEPROM_M24M02",
+    "EEPROM_M24M02x2"
 ]
 
 BL_TIME_VALUES = [0, 5, 10, 20, 60, 120, 255]
@@ -915,13 +915,13 @@ TX_CODE_TYPES = RX_CODE_TYPES = ["None", "CTCSS", "DCS", "-DCS"]
 
 EEPROM_TYPE_NAMES = [
     "none 1",  # 000
-    "none 2",  # 001
-    "BL24C64 (stock)",  # 010
-    "BL24C128",  # 011
-    "BL24C256",  # 100
-    "BL24C512",  # 101
-    "BL24C1024",  # 110
-    "M24M02 (x1)",  # 111
+    "BL24C64 (stock)",  # 001
+    "BL24C128",  # 010
+    "BL24C256",  # 011
+    "BL24C512",  # 100
+    "BL24C1024",  # 101
+    "M24M02 (x1)",  # 110
+    "M24M02 (x2)",  # 111
 ]
 
 APP_LIST = [

--- a/src/apps/memview.c
+++ b/src/apps/memview.c
@@ -6,25 +6,24 @@
 #include "apps.h"
 
 static uint32_t page = 0;
-static const uint8_t PAGE_SZ = 64;
 static uint16_t pagesCount;
 
-void MEMVIEW_Init(void) { pagesCount = SETTINGS_GetEEPROMSize() / PAGE_SZ; }
+void MEMVIEW_Init(void) { pagesCount = __EEPROM_SIZE / __EEPROM_PAGESIZE; }
 
 void MEMVIEW_Update(void) {}
 
 void MEMVIEW_Render(void) {
-  uint8_t buf[64] = {0};
-  EEPROM_ReadBuffer(page * PAGE_SZ, buf, PAGE_SZ);
+  uint8_t buf[__EEPROM_PAGESIZE];
+  EEPROM_ReadBuffer(page * __EEPROM_PAGESIZE, buf, __EEPROM_PAGESIZE);
 
   UI_ClearScreen();
-  for (uint8_t i = 0; i < PAGE_SZ; ++i) {
+  for (uint8_t i = 0; i < __EEPROM_PAGESIZE; ++i) {
     uint8_t col = i % 8;
     uint8_t row = i / 8;
     uint8_t rowYBL = row * 6 + 8 + 5;
 
     if (i % 8 == 0) {
-      PrintSmall(0, rowYBL, "%u", page * PAGE_SZ + i);
+      PrintSmall(0, rowYBL, "%u", page * __EEPROM_PAGESIZE + i);
     }
 
     PrintSmall(16 + col * 9, rowYBL, "%02x", buf[i]);
@@ -45,10 +44,10 @@ bool MEMVIEW_key(KEY_Code_t k, bool bKeyPressed, bool bKeyHeld) {
     IncDec32(&page, 0, pagesCount, 1);
     return true;
   case KEY_3:
-    IncDec32(&page, 0, pagesCount, -8196 / PAGE_SZ);
+    IncDec32(&page, 0, pagesCount, -8196 / __EEPROM_PAGESIZE);
     return true;
   case KEY_9:
-    IncDec32(&page, 0, pagesCount, 8196 / PAGE_SZ);
+    IncDec32(&page, 0, pagesCount, 8196 / __EEPROM_PAGESIZE);
     return true;
   case KEY_MENU:
     return false;

--- a/src/apps/reset.c
+++ b/src/apps/reset.c
@@ -19,8 +19,6 @@ static uint8_t vfosWrote = 0;
 static bool settingsWrote = 0;
 static uint8_t buf[8];
 
-static EEPROMType eepromType;
-
 static VFO defaultVFOs[2] = {
     (VFO){
         .rx.f = 14550000,
@@ -36,27 +34,8 @@ static VFO defaultVFOs[2] = {
     },
 };
 
-static EEPROMType determineEepromType() {
-  const uint8_t A = 33;
-  const uint8_t B = 55;
-  uint8_t bufA[1];
-  uint8_t bufB[1];
-  for (uint8_t i = ARRAY_SIZE(EEPROM_SIZES)-1; i > 0; --i) {
-    uint32_t sz = EEPROM_SIZES[i]-1;
-    EEPROM_WriteBuffer(0, (uint8_t[]){A}, 1);
-    EEPROM_WriteBuffer(sz, (uint8_t[]){B}, 1);
-    EEPROM_ReadBuffer(0, bufA, 1);
-    EEPROM_ReadBuffer(sz, bufB, 1);
-    if (bufA[0] == A && bufB[0] == B) {
-      return i;
-    }
-  }
-  return 0;
-}
-
 void RESET_Init(void) {
-  eepromType = determineEepromType();
-  gSettings.eepromType = eepromType;
+  gSettings.eepromType = __EEPROM_CODE;
   presetsWrote = 0;
   vfosWrote = 0;
   bytesWrote = 0;
@@ -70,7 +49,7 @@ void RESET_Init(void) {
 void RESET_Update(void) {
   if (!settingsWrote) {
     gSettings = (Settings){
-        .eepromType = eepromType,
+        .eepromType = __EEPROM_CODE,
         .squelch = 4,
         .scrambler = 0,
         .batsave = 4,
@@ -138,7 +117,7 @@ void RESET_Render(void) {
   DrawRect(0, POS_Y, LCD_WIDTH, 10, C_FILL);
   FillRect(1, POS_Y, progressX, 10, C_FILL);
   PrintMedium(0, 16, "%u/%u", channelsWrote, channelsMax);
-  PrintMedium(0, 24, "%lu", bytesMax);
+  PrintMedium(0, 24, "%lu/%lu", __EEPROM_SIZE, bytesMax);
   PrintMediumEx(LCD_XCENTER, POS_Y + 8, POS_C, C_INVERT, "%u%",
                 bytesWrote * 100 / bytesMax);
 }

--- a/src/driver/eeprom.c
+++ b/src/driver/eeprom.c
@@ -2,38 +2,53 @@
 #include "../driver/i2c.h"
 #include "../driver/system.h"
 #include "../settings.h"
+#include "driver/uart.h"
+#include "ARMCM0.h"
 #include <stddef.h>
 #include <string.h>
 
-bool gEepromWrite = false;
+const uint32_t EEPROM_SIZES[8] = { 8192, 8192, 16384, 32768, 65536, 131072, 262144, 524288 };
+
+const uint16_t PAGE_SIZES[8] = { 32, 32, 64, 64, 128, 128, 128, 128 };
+
+uint32_t EEPROM_GetSize() {
+  return EEPROM_SIZES[(int)__EEPROM_CODE];
+};
+
+uint16_t EEPROM_GetPageSize() {
+  return PAGE_SIZES[(int)__EEPROM_CODE];
+};
 
 void EEPROM_ReadBuffer(uint32_t address, void *pBuffer, uint16_t size) {
-  uint8_t IIC_ADD = (uint8_t)(0xA0 | ((address / 0x10000) << 1));
+    // uint8_t IIC_ADD = 0xA0 | address >> 15 & 14;
+    uint8_t IIC_ADD = (uint8_t)(0xA0 | ((address / 0x10000) << 1));
 
-  I2C_Start();
-  I2C_Write(IIC_ADD);
-  I2C_Write((address >> 8) & 0xFF);
-  I2C_Write(address & 0xFF);
-  I2C_Start();
-  I2C_Write(IIC_ADD + 1);
-  I2C_ReadBuffer(pBuffer, size);
-  I2C_Stop();
+    __disable_irq();
+    I2C_Start();
+    I2C_Write(IIC_ADD);
+    I2C_Write((address >> 8) & 0xFF);
+    I2C_Write(address & 0xFF);
+    I2C_Start();
+    I2C_Write(IIC_ADD + 1);
+    I2C_ReadBuffer(pBuffer, size);
+    I2C_Stop();
+    __enable_irq();
 }
 
-static uint8_t tmpBuffer[128];
 void EEPROM_WriteBuffer(uint32_t address, void *pBuffer, uint16_t size) {
   if (pBuffer == NULL) {
     return;
   }
-  const uint8_t PAGE_SIZE = SETTINGS_GetPageSize();
-
+  
+  uint8_t tmpBuffer[EEPROM_GetPageSize()];
   while (size) {
-    uint16_t i = address % PAGE_SIZE;
-    uint16_t rest = PAGE_SIZE - i;
+    uint16_t i = address % EEPROM_GetPageSize();
+    uint16_t rest = EEPROM_GetPageSize() - i;
     uint16_t n = size < rest ? size : rest;
 
     EEPROM_ReadBuffer(address, tmpBuffer, n);
     if (memcmp(pBuffer, tmpBuffer, n) != 0) {
+      // uint8_t IIC_ADD = 0xA0 | address >> 15 & 14;
       uint8_t IIC_ADD = (uint8_t)(0xA0 | ((address / 0x10000) << 1));
 
       I2C_Start();
@@ -50,6 +65,5 @@ void EEPROM_WriteBuffer(uint32_t address, void *pBuffer, uint16_t size) {
     pBuffer += n;
     address += n;
     size -= n;
-    gEepromWrite = true;
   }
 }

--- a/src/driver/eeprom.h
+++ b/src/driver/eeprom.h
@@ -4,9 +4,43 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-extern bool gEepromWrite;
+void EEPROM_ReadBuffer(uint32_t address, void *pBuffer, uint16_t size);
+void EEPROM_WriteBuffer(uint32_t address, void *pBuffer, uint16_t size);
 
-void EEPROM_ReadBuffer(uint32_t Address, void *pBuffer, uint16_t Size);
-void EEPROM_WriteBuffer(uint32_t Address, void *pBuffer, uint16_t Size);
+// #if __EEPROM == BL24C128
+#if __EEPROM == 2
+  #define __EEPROM_SIZE (uint32_t)16384
+  #define __EEPROM_PAGESIZE (uint8_t)64
+  #define __EEPROM_CODE (uint8_t)0x02
+// #elif __EEPROM == BL24C256
+#elif __EEPROM == 3
+  #define __EEPROM_SIZE (uint32_t)32768
+  #define __EEPROM_PAGESIZE (uint8_t)64
+  #define __EEPROM_CODE (uint8_t)0x03
+// #elif __EEPROM == BL24C512
+#elif __EEPROM == 4
+  #define __EEPROM_SIZE (uint32_t)65536
+  #define __EEPROM_PAGESIZE (uint8_t)128
+  #define __EEPROM_CODE (uint8_t)0x04
+// #elif __EEPROM == BL24C1024
+#elif __EEPROM == 5
+  #define __EEPROM_SIZE (uint32_t)131072
+  #define __EEPROM_PAGESIZE (uint8_t)128
+  #define __EEPROM_CODE (uint8_t)0x05
+// #elif __EEPROM == M24M02
+#elif __EEPROM == 6
+  #define __EEPROM_SIZE (uint32_t)262144
+  #define __EEPROM_PAGESIZE (uint8_t)128
+  #define __EEPROM_CODE (uint8_t)0x06
+// #elif __EEPROM == M24M02x2
+#elif __EEPROM == 7
+  #define __EEPROM_SIZE (uint32_t)524288
+  #define __EEPROM_PAGESIZE (uint8_t)128
+  #define __EEPROM_CODE (uint8_t)0x07
+#else
+  #define __EEPROM_SIZE (uint32_t)8192
+  #define __EEPROM_PAGESIZE (uint8_t)32
+  #define __EEPROM_CODE (uint8_t)0x01
+#endif
 
 #endif

--- a/src/driver/si473x.c
+++ b/src/driver/si473x.c
@@ -52,9 +52,7 @@ void waitToSend() {
 
 bool SI47XX_downloadPatch() {
   uint8_t buf[248];
-  // const uint8_t PAGE_SIZE = SETTINGS_GetPageSize();
-  const uint32_t EEPROM_SIZE = SETTINGS_GetEEPROMSize();
-  const uint32_t PATCH_START = EEPROM_SIZE - PATCH_SIZE;
+  const uint32_t PATCH_START = __EEPROM_SIZE - PATCH_SIZE;
   for (uint16_t offset = 0; offset < PATCH_SIZE; offset += 248) {
     uint32_t eepromN = PATCH_SIZE - offset > 248 ? 248 : PATCH_SIZE - offset;
     EEPROM_ReadBuffer(PATCH_START + offset, buf, eepromN);

--- a/src/helper/channels.c
+++ b/src/helper/channels.c
@@ -19,12 +19,11 @@ static uint32_t getChannelsStart() {
 }
 
 static uint32_t getChannelsEnd() {
-  uint32_t eepromSize = SETTINGS_GetEEPROMSize();
   uint32_t minSizeWithPatch = getChannelsStart() + CH_SIZE + PATCH_SIZE;
-  if (eepromSize < minSizeWithPatch) {
-    return eepromSize;
+  if (__EEPROM_SIZE < minSizeWithPatch) {
+    return __EEPROM_SIZE;
   }
-  return eepromSize - PATCH_SIZE;
+  return __EEPROM_SIZE - PATCH_SIZE;
 }
 
 static uint32_t GetChannelOffset(int32_t num) {

--- a/src/main.c
+++ b/src/main.c
@@ -44,17 +44,19 @@ void uartHandle() {
 }
 
 static void unreborn(void) {
-  uint8_t tpl[128];
-  const uint32_t EEPROM_SIZE = SETTINGS_GetEEPROMSize();
-  const uint8_t PAGE_SIZE = SETTINGS_GetPageSize();
+  uint8_t tpl[__EEPROM_PAGESIZE];
+//  const uint32_t EEPROM_SIZE = EEPROM_GetSize();
+//  const uint8_t PAGE_SIZE = EEPROM_GetPageSize();
 
-  memset(tpl, 0xFF, 128);
+  Log("mem %d %d %s", __EEPROM_SIZE, __EEPROM_PAGESIZE, __EEPROM);
 
-  for (uint16_t i = 0; i < EEPROM_SIZE; i += PAGE_SIZE) {
-    EEPROM_WriteBuffer(i, tpl, PAGE_SIZE);
+  memset(tpl, 0xFF, __EEPROM_PAGESIZE);
+
+  for (uint32_t i = 0; i < __EEPROM_SIZE; i += __EEPROM_PAGESIZE) {
+    EEPROM_WriteBuffer(i, tpl, __EEPROM_PAGESIZE);
     UI_ClearScreen();
     PrintMediumEx(LCD_XCENTER, LCD_YCENTER, POS_C, C_FILL, "0xFFing... %u",
-                  i * 100 / EEPROM_SIZE);
+                  i * 100 / __EEPROM_SIZE);
     ST7565_Blit();
   }
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -14,38 +14,7 @@ const char *TX_OFFSET_NAMES[3] = {"None", "+", "-"};
 const char *TX_CODE_TYPES[4] = {"None", "CT", "DCS", "-DCS"};
 const char *rogerNames[4] = {"None", "Moto", "Tiny", "Call"};
 const char *dwNames[3] = {"Off", "TX Stay", "TX Switch"};
-const char *EEPROM_TYPE_NAMES[8] = {
-    "-",      // 000
-    "-",      // 001
-    "BL24C64 #",   // 010
-    "BL24C128",    // 011
-    "BL24C256",    // 100
-    "BL24C512",    // 101
-    "BL24C1024",   // 110
-    "M24M02", // 111
-};
 
-const uint32_t EEPROM_SIZES[8] = {
-    8192,   // 000
-    8192,   // 001
-    8192,   // 010
-    16384,  // 011
-    32768,  // 100
-    65536,  // 101
-    131072, // 110
-    262144, // 111
-};
-
-const uint16_t PAGE_SIZES[8] = {
-    32,  // 000
-    32,  // 001
-    32,  // 010
-    64,  // 011
-    64,  // 100
-    128, // 101
-    128, // 110
-    128, // 111
-};
 
 void SETTINGS_Save(void) {
   EEPROM_WriteBuffer(SETTINGS_OFFSET, &gSettings, SETTINGS_SIZE);
@@ -63,9 +32,3 @@ void SETTINGS_DelayedSave(void) {
 uint32_t SETTINGS_GetFilterBound(void) {
   return gSettings.bound_240_280 ? VHF_UHF_BOUND2 : VHF_UHF_BOUND1;
 }
-
-uint32_t SETTINGS_GetEEPROMSize(void) {
-  return EEPROM_SIZES[gSettings.eepromType];
-}
-
-uint16_t SETTINGS_GetPageSize(void) { return PAGE_SIZES[gSettings.eepromType]; }

--- a/src/settings.h
+++ b/src/settings.h
@@ -254,7 +254,5 @@ void SETTINGS_Save();
 void SETTINGS_Load();
 void SETTINGS_DelayedSave();
 uint32_t SETTINGS_GetFilterBound();
-uint32_t SETTINGS_GetEEPROMSize();
-uint16_t SETTINGS_GetPageSize();
 
 #endif /* end of include guard: SETTINGS_H */

--- a/src/ui/statusline.c
+++ b/src/ui/statusline.c
@@ -17,7 +17,6 @@ static bool lastEepromWrite = false;
 static char statuslineText[32] = {0};
 
 static void eepromRWReset(void) {
-  lastEepromWrite = gEepromWrite = false;
   gRedrawScreen = true;
 }
 
@@ -46,12 +45,6 @@ void STATUSLINE_update(void) {
     previousBatteryLevel = level;
     gRedrawScreen = true;
   }
-
-  if (lastEepromWrite != gEepromWrite) {
-    lastEepromWrite = gEepromWrite;
-    gRedrawScreen = true;
-    TaskAdd("EEPROM RW-", eepromRWReset, 500, false, 0);
-  }
 }
 
 void STATUSLINE_render(void) {
@@ -78,10 +71,6 @@ void STATUSLINE_render(void) {
 
   char icons[8] = {'\0'};
   uint8_t idx = 0;
-
-  if (gEepromWrite) {
-    icons[idx++] = SYM_EEPROM_W;
-  }
 
   if (SVC_Running(SVC_BEACON)) {
     icons[idx++] = SYM_BEACON;


### PR DESCRIPTION
Убирает определение в runtime размера памяти. Теперь можно указать тип памяти в makefile перед сборкой.

Тем не менее в настройки тип памяти сохраняется для использования в chirp